### PR TITLE
Migrate codebase to use sanic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *test*
 *__pycache__*
 entries/
+typings/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.analysis.typeCheckingMode": "strict"
+    "python.analysis.typeCheckingMode": "standard"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [WIP] Paste Service
 
-A work-in-progress that combines a Python backend (written with FastAPI) and a Flutter frontend (running on web).
+A work-in-progress that combines a Python backend (written with `sanic`) and a Flutter frontend (running on web).
 
 Please ignore the _awful_ state of the repository right now.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Backend - FastAPI with Python
 
-The backend of this pastebin application was written using FastAPI, which was incredibly simple and easy to use.
+The backend of this pastebin application was written using [`sanic`](https://sanic.dev/en/), which was incredibly simple and easy to use.
 
 > :wrench::memo: **Note:** The background tasks that delete pastes after they've expired uses [`discord.py`](https://github.com/Rapptz/discord.py)'s [`tasks.loop`](https://github.com/Rapptz/discord.py/blob/master/discord/ext/tasks/__init__.py#L768) decorator, wrapped in my own [`BackgroundLoops`](https://github.com/axololly/paste/tree/main/backend/paste/loops.py#L7-L52) class.
 

--- a/backend/docs/schema.md
+++ b/backend/docs/schema.md
@@ -1,0 +1,48 @@
+# :oil_drum: Database Schema
+
+> :memo: :wrench: **Note:** the database behind this project is the all-amazing SQLite, interfaced by [Rapptz's](https://github.com/Rapptz) `sqlite3` wrapper: [`asqlite`](https://github.com/Rapptz/asqlite).
+
+This section of the documentation goes over how the database is arranged.
+
+There are only two tables, so don't be afraid.
+
+## 1. `pastes` - Where your pastes are
+
+This is where all the general information about a paste is stored - things like its unique ID, expiration timestamp and deletion link are found here.
+
+To save on space, a maximum of 100,000 (subject to change) rows are allowed in this table. A `403` response is sent for requests made after this limit is reached.
+
+### SQL
+
+```sql
+CREATE TABLE pastes (
+    id TEXT NOT NULL UNIQUE,
+    expiration INT NOT NULL,
+    removal_id TEXT NOT NULL,
+    
+    PRIMARY KEY (id)
+);
+```
+
+## 2. `files` - Where each paste's files are
+
+This is where every file in every paste is located. The contents are compressed using `zlib`'s `compress` function, allowing 100 KB to be squeezed down into around 16 KB, making storage far more efficient.
+
+There is also a `filepos` column that lets you retain the order of files after pasting.
+
+### SQL
+
+```sql
+CREATE TABLE files (
+    id TEXT NOT NULL UNIQUE,
+    filename TEXT,
+    content BLOB NOT NULL,
+    filepos INT NOT NULL DEFAULT 1
+);
+```
+
+***
+
+That's it! Nothing more to see...
+
+...for now. :eyes:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,42 +1,39 @@
 from asqlite import create_pool
-from contextlib import asynccontextmanager
-from fastapi import Request
-from fastapi.responses import StreamingResponse
 from paste.create import create_new_paste
 from paste.delete import delete_paste_by_link
 from paste.download import download_paste_by_id
 from paste.get import get_paste_by_id, get_raw_paste_by_id
 from paste._types import CreateSuccess, GetSuccess, Reply
 from paste.update import update_existing_paste
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from utils import BackgroundLoops, MyAPI
 
-limiter = Limiter(key_func = get_remote_address)
+from sanic_limiter import Limiter, get_remote_address # type: ignore
+from sanic.response import HTTPResponse
+from sanic.request import Request
 
-@asynccontextmanager
-async def lifespan(app: MyAPI):
-    async with create_pool("entries/index.sql") as pool:
-        app.pool = pool
-        app.loops = BackgroundLoops(app)
-        app.loops.start()
-        
-        yield
+app = MyAPI("pastolotl-backend")
+limiter = Limiter(app, key_func = get_remote_address)
 
-app = MyAPI(lifespan = lifespan)
+@app.before_server_start
+async def before_start(app: MyAPI) -> None:
+    app.ctx.pool = await create_pool("../entries/index.sql")
+    
+    app.ctx.loops = BackgroundLoops(app)
+    app.ctx.loops.start()
 
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler) # type: ignore
+@app.after_server_stop
+async def after_end(app: MyAPI) -> None:
+    await app.ctx.pool.close()
+    
+    app.ctx.loops.end()
 
-
-@app.post("/create/", response_model = None)
+@app.post("/create/")
 @limiter.limit("6/minute") # type: ignore # 10s per request
 async def app_create_new_paste(request: Request) -> CreateSuccess | Reply:
     return await create_new_paste(app, request)
 
 
-@app.get("/get/{paste_id}", response_model = None)
+@app.get("/get/{paste_id}")
 @limiter.limit("20/minute") # type: ignore # 3s per request
 async def app_get_paste_by_id(request: Request, paste_id: str) -> GetSuccess | Reply:
     return await get_paste_by_id(app, paste_id)
@@ -64,17 +61,20 @@ async def app_update_existing_paste(request: Request) -> Reply:
     return await update_existing_paste(app, request)
 
 
-@app.get("/download/{paste_id}", response_model = None)
+@app.get("/download/{paste_id}")
 @limiter.limit("2/minute") # type: ignore
-async def app_download_paste_by_id(request: Request, paste_id: str) -> StreamingResponse | Reply:
-    return await download_paste_by_id(app, paste_id)
+async def app_download_paste_by_id(request: Request, paste_id: str) -> HTTPResponse | Reply:
+    return await download_paste_by_id(app, request, paste_id)
 
-@app.get("/download/{paste_id}/{filepos}", response_model = None)
+@app.get("/download/{paste_id}/{filepos}")
 @limiter.limit("2/minute") # type: ignore
-async def app_download_single_paste_by_id(request: Request, paste_id: str, filepos: int) -> StreamingResponse | Reply:
-    return await download_paste_by_id(app, paste_id, filepos)
+async def app_download_single_paste_by_id(request: Request, paste_id: str, filepos: int) -> HTTPResponse | Reply:
+    return await download_paste_by_id(app, request, paste_id, filepos)
+
 
 if __name__ == '__main__':
-    import uvicorn
-    
-    uvicorn.run("main:app")
+    from os import chdir as run_from
+    from subprocess import run
+
+    run_from("./backend")
+    run("sanic main:app --debug".split(' '))

--- a/backend/paste/delete.py
+++ b/backend/paste/delete.py
@@ -2,7 +2,7 @@ from utils import error_404, MyAPI, success
 from ._types import Reply
 
 async def delete_paste_by_link(app: MyAPI, removal_id: str) -> Reply:
-    async with app.pool.acquire() as conn:
+    async with app.ctx.pool.acquire() as conn:
         req = await conn.execute("SELECT 1 FROM pastes WHERE removal_id = ?", removal_id)
         row = await req.fetchone()
 

--- a/backend/paste/download.py
+++ b/backend/paste/download.py
@@ -1,17 +1,28 @@
-from fastapi.responses import StreamingResponse
 from io import BytesIO
 from ._types import Reply
-# from typing import overload
+from sanic.response import HTTPResponse
+from sanic.response.convenience import raw
+from sanic.request import Request
+from typing import overload
 from utils import error_400, error_404, MyAPI
 from zipfile import ZipFile, ZIP_DEFLATED
+from zlib import decompress
 
-async def download_paste_by_id(app: MyAPI, paste_id: str, filepos: int = 0) -> StreamingResponse | Reply:
+@overload
+async def download_paste_by_id(app: MyAPI, request: Request, paste_id: str) -> HTTPResponse | Reply:
+    "Download all files under the given `paste_id`."
+
+@overload
+async def download_paste_by_id(app: MyAPI, request: Request, paste_id: str, filepos: int) -> HTTPResponse | Reply:
+    "Download a single file at position `filepos` under the given `paste_id`."
+
+async def download_paste_by_id(app: MyAPI, request: Request, paste_id: str, filepos: int = 0) -> HTTPResponse | Reply:
     if filepos < 0:
         return error_400("'filepos' cannot be less than zero.")
     
     # User wants to download a single file
     if filepos:
-        async with app.pool.acquire() as conn:
+        async with app.ctx.pool.acquire() as conn:
             req = await conn.execute(
                 """
                 SELECT filename, content FROM files
@@ -25,36 +36,32 @@ async def download_paste_by_id(app: MyAPI, paste_id: str, filepos: int = 0) -> S
         if not row:
             return error_404(f"No file at index {filepos} for paste {paste_id} found.")
     
-        return StreamingResponse(
-            content = BytesIO(row["content"].encode()),
-            media_type = "text",
-            headers = {
-                "Content-Disposition": f"inline; filename={row['filename'] or paste_id}"
-            }
-        )
+        text = decompress(row["content"]).decode()
+
+        ...
 
     # ================================================================================================
 
     # User wants to download all files
-    async with app.pool.acquire() as conn:
+    async with app.ctx.pool.acquire() as conn:
         req = await conn.execute("SELECT filename, content, position FROM files WHERE id = ?", paste_id)
         rows = await req.fetchall()
     
     if not rows:
         return error_404(f"No files were found with the paste ID '{paste_id}'.")
 
-    with BytesIO() as buffer:
-        with ZipFile(buffer, "a", ZIP_DEFLATED, False) as myzip:
-            for row in rows:
-                filename = f"{paste_id}-{row["filename"] or row["position"]}"
-
-                with myzip.open(filename, "w") as file:
-                    file.write(row["content"])
+    buffer = BytesIO()
     
-        return StreamingResponse(
-            content = buffer,
-            media_type = "text",
-            headers = {
-                "Content-Disposition": f"inline; filename={paste_id}.zip"
-            }
-        )
+    with ZipFile(buffer, "a", ZIP_DEFLATED, False) as myzip: # type: ignore
+        for row in rows:
+            filename = f"{paste_id}-{row["filename"] or row["position"]}"
+
+            with myzip.open(filename, "w") as file:
+                text = decompress(row["content"]).decode()
+                
+                file.write(text) # type: ignore
+    
+    return raw(
+        buffer.getvalue(),
+        content_type = "file/zip"
+    )


### PR DESCRIPTION
From the suggestions of the other people in the [Python Discord server](https://discord.com/invite/python), I decided to migrate the backend framework from FastAPI to [`sanic`](https://sanic.dev/en/), which was certainly much easier and more intuitive to use, compared to FastAPI.

I'm glad this is now behind me.